### PR TITLE
customize google maps presentation

### DIFF
--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -12,7 +12,7 @@ const mapContainerStyle = {
 const mapOptions: google.maps.MapOptions = {
   mapTypeControl: false, // Removes the map/satellite toggle
   streetViewControl: false, // Removes Street View
-  zoom: 16, // A good default to see a few streets
+  zoom: 17, // A good default to see a few streets
 };
 
 interface LocationMapProps {


### PR DESCRIPTION
Tweaks the google maps widget used for the last seen location input to be a little less noisy. Removes streetview, satellite toggle, etc. Also sets a good default for zoom. 

![CleanShot 2024-09-15 at 13 06 30@2x](https://github.com/user-attachments/assets/791e0a47-d6e3-45bf-8eca-fd44fadf5ab7)
