### PR TITLE
Add asset caching

### DIFF
--- a/src/app/pages/cloud-assets.ts
+++ b/src/app/pages/cloud-assets.ts
@@ -19,7 +19,11 @@ export const cloudAssetRoutes = [
 		const contentType =
 			asset.httpMetadata?.contentType || "application/octet-stream";
 		return new Response(asset.body, {
-			headers: { "Content-Type": contentType },
+			headers: {
+				"Content-Type": contentType,
+				"Cache-Control": "public, max-age=600",
+				"ETag": manifest[file].hash,
+			},
 		});
 	}),
 ];


### PR DESCRIPTION
This adds headers to the `/cloud-assets` route to ensure it returns appropriate cache headers. Given that the assets behind that route are content addressed, I use the content hash as an ETag for the resource. Otherwise there's a 10 min TTL that should probably cover a single session but not gunk up asset iterations too much. 